### PR TITLE
feat: stream microphone input and display audio metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,46 @@ Do NOT put phase numbers in branch names. Use tags for milestones.
 - `chore: remove unused v0.1 files`
 - `refactor: simplify gauge HTML`
 
+## Development Workflow — Balanced with Claude Code
+
+This project is built step-by-step as a learning portfolio. Claude Code is a
+co-pilot, not an autopilot. The workflow balances speed with understanding.
+
+### Per-issue cycle
+
+1. **Goal** — I state what I want to build (one sentence)
+2. **Scaffold** — Claude generates working code or a starting point
+3. **Understand** — I read every line. If something is unclear, I ask "why?"
+4. **Modify** — I adjust to my style, rename variables, add my own touches
+5. **Test** — `python app.py` (or pytest) after every change
+6. **Commit** — only code I can explain. `git add <specific files>`, never `git add .`
+7. **PR + review** — Claude runs the review skill, I read findings, fix if needed
+8. **Merge + close** — squash merge, pull main, close issue with learning summary
+
+### Principles
+
+- **Don't commit code I can't explain.** Claude can write it, but I must understand it before it enters main.
+- **Ask "why?" freely.** No question is too basic. Understanding > speed.
+- **Print-first debugging.** When unsure what data looks like, `print()` it before writing logic.
+- **Spike → implement.** For unfamiliar APIs, explore first (30 min), then plan. Don't write detailed checklists for things you haven't tried.
+- **Small PRs, single purpose.** One issue = one branch = one PR. Each PR should be reviewable in under 5 minutes.
+- **Learning notes in every PR.** The "Learning notes" section in PR body is mandatory — it's the portfolio's voice.
+
+### What Claude should do
+
+- Generate code scaffolds when asked
+- Explain concepts using C analogies (user has 2+ years of C background)
+- Fix bugs directly (edit the file) rather than just describing what to change
+- Keep explanations concise — teach the concept, not the textbook
+- Flag security/performance issues proactively in reviews
+
+### What Claude should NOT do
+
+- Write full solutions without being asked — offer scaffolds and let user fill gaps
+- Give 30-minute reading assignments (`help()`, docs deep-dives) as the first step
+- Over-explain when user says "했다" (done) — move to next step quickly
+- Add features beyond what the current issue asks for
+
 ## Skill routing
 
 When the user's request matches an available skill, ALWAYS invoke it using the Skill

--- a/app.py
+++ b/app.py
@@ -1,7 +1,23 @@
 import gradio as gr
+import numpy as np
 
-with gr.Blocks(title="Sentinel") as app:
-    gr.Markdown("# Hello World!")
+def process_audio(audio_data):
+    if audio_data is None:
+        return ""
+    sample_rate, audio = audio_data
+    return f"{sample_rate=}, {audio.shape=}, {audio.dtype=}"
+
+with gr.Blocks() as app:
+    gr.Markdown("#Microphone Input")
+    audio_input = gr.Audio(sources="microphone", streaming=True, type="numpy")
+
+    output = gr.Markdown("checking terminal...")
+
+    audio_input.stream(
+        fn=process_audio,
+        inputs=[audio_input],
+        outputs=[output],
+    )
 
 if __name__ == "__main__":
     app.launch()

--- a/app.py
+++ b/app.py
@@ -1,5 +1,4 @@
 import gradio as gr
-import numpy as np
 
 def process_audio(audio_data):
     if audio_data is None:
@@ -8,7 +7,7 @@ def process_audio(audio_data):
     return f"{sample_rate=}, {audio.shape=}, {audio.dtype=}"
 
 with gr.Blocks() as app:
-    gr.Markdown("#Microphone Input")
+    gr.Markdown("# Microphone Input")
     audio_input = gr.Audio(sources="microphone", streaming=True, type="numpy")
 
     output = gr.Markdown("checking terminal...")


### PR DESCRIPTION
## Summary

- Stream browser microphone into Python via `gr.Audio(streaming=True, type="numpy")`
- Display audio chunk metadata (sample rate, shape, dtype) in real-time via `gr.Markdown`
- Add balanced workflow guidelines to `CLAUDE.md`

## Key observations (from print-debugging)

- `sample_rate=48000` — standard browser mic rate
- `audio.shape=(24000, 2)` — stereo (duplicated mono), 500ms chunks
- `audio.dtype=int16` — 16-bit signed, needs normalization for future dB math

## Test plan

- [x] `python app.py` starts server on localhost:7860
- [x] Browser prompts for mic permission
- [x] Recording shows metadata updating ~2x/sec in Markdown area
- [x] `Ctrl+C` graceful shutdown

## Learning notes

- **Callback = C function pointer** — `fn=process_audio` passes the function itself (no parentheses), Gradio calls it on each chunk
- **`inputs`/`outputs` separation** — event source and data source are independent concepts. `audio.stream(inputs=[audio])` looks self-referential but is intentional API design for generality
- **`NULL` → `None`** — Python's null, compared with `is` not `==`. C habit caught during review
- **`f"{x=}"` debug syntax** — Python 3.8+ shorthand, preferred for quick debug output
- **Print-first debugging** — observing real data (stereo! int16!) before writing logic prevented wrong assumptions
- **Balanced workflow** — Claude scaffolds → I understand → I modify → commit. Added to CLAUDE.md as project standard

Closes #13
