### PR TITLE
feat: compute real-time dB from microphone audio

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,17 +1,37 @@
 import gradio as gr
+import numpy as np
+
+def compute_volume_db(audio):
+    """Convert raw audio samples to decibels (dB)."""
+    if len(audio) == 0:
+        return 0.0
+    
+    original_dtype = audio.dtype
+
+    if audio.ndim > 1:
+        audio = audio.mean(axis=1)
+    
+    audio_f = audio.astype(np.float32)
+    if np.issubdtype(original_dtype, np.integer):
+        audio_f = audio_f / max(np.iinfo(audio.dtype).max, 1)
+
+    rms = float(np.sqrt(np.mean(audio_f ** 2)))
+    if rms < 1e-10:
+        return 0.0
+    db = 20 * np.log10(rms) + 94
+    return max(db, 0.0)
 
 def process_audio(audio_data):
     if audio_data is None:
-        return ""
+        return "Waiting for audio..."
     sample_rate, audio = audio_data
-    return f"{sample_rate=}, {audio.shape=}, {audio.dtype=}"
+    db = compute_volume_db(audio)
+    return f"Volume: {db:.1f} dB"
 
 with gr.Blocks() as app:
-    gr.Markdown("# Microphone Input")
+    gr.Markdown("# Sentinel - Volume Monitor")
     audio_input = gr.Audio(sources="microphone", streaming=True, type="numpy")
-
-    output = gr.Markdown("checking terminal...")
-
+    output = gr.Markdown("Waiting for audio...")
     audio_input.stream(
         fn=process_audio,
         inputs=[audio_input],
@@ -19,4 +39,4 @@ with gr.Blocks() as app:
     )
 
 if __name__ == "__main__":
-    app.launch()
+    app.launch(share=True)


### PR DESCRIPTION
## Summary

- Add `compute_volume_db()` function: stereo→mono, int16 normalization, RMS, dB conversion
- Replace metadata display with live dB readout (~2x/sec updates)

## Data flow (interview-ready)

mic chunk (48000, array(24000,2) int16)
→ stereo→mono: mean(axis=1) → (24000,)
→ normalize: /32768 → float [-1,1]
→ RMS: sqrt(mean(x²)) → single float
→ dB: 20*log10(rms)+94 → human-readable number
→ "Volume: 52.3 dB"



## Test plan

- [x] Silence → ~40 dB
- [x] Speaking → ~55-65 dB
- [x] Loud voice → ~70+ dB
- [x] No crash on empty array or None input

## Learning notes

- **Stereo surprise**: browser sends shape=(24000,2) even for mono mic. `mean(axis=1)` averages L/R channels
- **int16 normalization**: divide by `np.iinfo(dtype).max` — same as C's `INT16_MAX` from `<limits.h>`
- **RMS**: "average loudness" — square each sample, mean, square root. C equivalent: `sqrt(sum(x[i]*x[i])/n)`
- **+94 offset**: acoustics convention mapping digital 0 dBFS to ~94 dB SPL
- **Silence guard**: `rms < 1e-10` prevents `log10(0) = -infinity`
- **Senior coding pattern**: stub first (`return 0.0`), fill in logic step by step, test at each stage

Closes #15
