### PR TITLE
feat: add HTML volume gauge with color-coded thresholds

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,30 @@
 import gradio as gr
 import numpy as np
 
+def generate_gauge_html(db):
+    """Return HTML with volume bar + color label."""
+    if db >= 70:
+        color, label = "red", "LOUD"
+    elif db >= 60:
+        color, label = "orange", "MODERATE"
+    else:
+        color, label = "green", "QUIET"
+
+    pct = min(max((db - 30) / 70 * 100, 0), 100)
+
+    return f"""
+    <div style="padding:16px;">
+        <p><strong>Volume:</strong> {db:.1f} dB -
+            <span style="color:{color};">{label}</span></p>
+        <div style="background:#ddd; border-radius:8px; height:24px;">
+            <div style="width:{pct:.1f}%; height:100%; background:{color};
+                border-radius:8px; transition:width 0.15s;">
+            </div>
+        </div>
+    </div>
+    """
+
+
 def compute_volume_db(audio):
     """Convert raw audio samples to decibels (dB)."""
     if len(audio) == 0:
@@ -23,15 +47,15 @@ def compute_volume_db(audio):
 
 def process_audio(audio_data):
     if audio_data is None:
-        return "Waiting for audio..."
+        return generate_gauge_html(0)
     sample_rate, audio = audio_data
     db = compute_volume_db(audio)
-    return f"Volume: {db:.1f} dB"
+    return generate_gauge_html(db)
 
 with gr.Blocks() as app:
     gr.Markdown("# Sentinel - Volume Monitor")
     audio_input = gr.Audio(sources="microphone", streaming=True, type="numpy")
-    output = gr.Markdown("Waiting for audio...")
+    output = gr.HTML(value=generate_gauge_html(0))
     audio_input.stream(
         fn=process_audio,
         inputs=[audio_input],


### PR DESCRIPTION
## Summary

- Add `generate_gauge_html(db)` — returns HTML with colored bar + label
- 3-tier thresholds: green/QUIET, orange/MODERATE, red/LOUD
- Switch output from `gr.Markdown` to `gr.HTML`
- **v0.0 Minimal Volume Gauge complete** 🎉

## Test plan

- [x] Silence → green bar, "QUIET", ~40 dB
- [x] Speaking → orange bar, "MODERATE", ~60 dB
- [x] Loud voice → red bar, "LOUD", ~70+ dB
- [x] Playwright screenshot confirms initial render

## Learning notes

- f-string HTML generation — Python builds HTML directly, no template engine needed
- `min(max(value, 0), 100)` — clamp pattern, same as C's common idiom
- `transition: width 0.15s` — one CSS property gives smooth animation
- Inline CSS vs stylesheet — inline is simpler for small components, no extra files to manage

Closes #16
