### PR TITLE
feat: add persistent alert banner and rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,178 +1,166 @@
-# Sentinel: Real-time Cognitive Assistant
+# Sentinel — Real-time Voice Volume Monitor
 
-[![Live](https://img.shields.io/badge/Live-sentinel.bit--habit.com-ff1744?style=for-the-badge&logo=kubernetes&logoColor=white)](https://sentinel.bit-habit.com)
-[![K3s](https://img.shields.io/badge/K3s-Oracle_OCI-326ce5?style=flat-square&logo=kubernetes)](https://sentinel.bit-habit.com)
-[![Python](https://img.shields.io/badge/Python-3.10-3776ab?style=flat-square&logo=python)](https://python.org)
-[![Hackathon](https://img.shields.io/badge/Megazone_Cloud-1st_Place-gold?style=flat-square)](https://sentinel.bit-habit.com)
+[![Python 3.14](https://img.shields.io/badge/Python-3.14-3776ab?style=flat-square&logo=python&logoColor=white)](https://python.org)
+[![Gradio 6](https://img.shields.io/badge/Gradio-6.12-f97316?style=flat-square)](https://gradio.app)
+[![NumPy](https://img.shields.io/badge/NumPy-2.4-013243?style=flat-square&logo=numpy)](https://numpy.org)
+[![Built with Claude Code](https://img.shields.io/badge/Built_with-Claude_Code-cc785c?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/code)
 
-A real-time voice monitor that detects raised voices and alerts people before conversations get out of hand. Built with **local-first computation** — no cloud API needed for core detection.
+A browser-based microphone monitor that computes dB levels in real-time and displays a color-coded volume gauge with persistent alert banners.
 
-**Live at https://sentinel.bit-habit.com**
-
-> **1st Place — Megazone Cloud AI Agent Hackathon**  
-> Weekly mentoring with Infobank CTO to validate tech decisions from a business perspective
+> **This is not vibe-coded.** Every line was typed by a human. Claude Code served as a **senior pair-programmer who can only talk — never touch the keyboard.** All code, all git commands, all terminal input was written by [Gichan](https://github.com/bookseal). See [How This Was Built](#how-this-was-built) below.
 
 ---
 
-## Why This Exists
+## What It Does
 
-When couples or coworkers argue, they often don't realize they're raising their voices. And it's awkward for others to point it out.
-
-No existing communication tool provides **real-time feedback on vocal tone**. Sentinel fills that gap — an AI that monitors conversations like a neutral third party and warns when things get heated.
-
----
-
-## Design Philosophy: Cost First
-
-We chose **local NumPy math** instead of expensive cloud APIs for core detection. LLM APIs will only be added in later versions where AI is actually needed (emotion analysis, etc.).
-
-| Factor | Cloud Speech API | Local NumPy (chosen) |
-|---|---|---|
-| **Cost** | ~$0.06/min | **$0.00** |
-| **Latency** | ~200ms (network) | **< 10ms** |
-| **Privacy** | Audio sent to third party | **Stays on device** |
-| **Availability** | Needs internet + API uptime | **Always works** |
-
-Volume detection doesn't need AI — it's pure signal math.
-
----
-
-## Current State: v0.1 (Volume + Pitch Guard)
-
-### Features
-
-- **Real-time volume (dB) gauge** — green / yellow / red
-- **10-second persistent alert** — warning stays visible long enough for people to notice
-- **Pitch detection (FFT)** — tracks vocal frequency in 85–400Hz range
-- **Adaptive sensitivity slider** (0.5–2.0) — quiet meeting room vs noisy cafe
-- **Mobile vibration** — device buzzes on alert
-- **Zero cloud API calls** — everything runs locally
-
-### Audio Pipeline
-
-```mermaid
-flowchart LR
-    MIC[Browser Mic] -->|500ms chunks| GS[Gradio Stream]
-    GS --> RS[Resample 16kHz]
-    RS --> RMS[NumPy RMS]
-    RMS --> DB[dB Conversion<br/>+94 SPL offset]
-    DB --> SW[Sliding Window<br/>5 chunks / 2.5s]
-    SW --> TC{Threshold<br/>Check}
-
-    TC --> N["Normal\n< 75 dB"]:::green
-    TC --> W["Warning\n75-85 dB"]:::yellow
-    TC --> R["RED ALERT\n≥ 85 dB"]:::red
-
-    classDef green fill:#00c853,stroke:#00c853,color:#000
-    classDef yellow fill:#ffd600,stroke:#ffd600,color:#000
-    classDef red fill:#ff1744,stroke:#ff1744,color:#fff
-```
-
-### Why a Sliding Window?
-
-| Decision | Value | Why |
-|---|---|---|
-| Window size | 5 chunks (2.5s) | A cough is < 500ms — affects only 1 of 5 readings. Real shouting lasts 1–2 seconds and pushes the average over the threshold |
-| `-inf` filtering | Silence excluded | Quiet moments don't mask loud ones |
-| Alert persistence | 10 seconds | Gives people time to notice and lower their voice |
-| Red > Yellow | No downgrade mid-alert | Red stays red even if a yellow-level sound follows |
-
-### dB Reference
-
-| dB SPL | What it sounds like |
-|---|---|
-| 30 | Whisper, quiet library |
-| 60 | Normal conversation |
-| 75 | Loud talking (**Warning threshold**) |
-| 85 | Shouting, heavy traffic (**Red Alert**, OSHA limit) |
-| 100 | Rock concert |
+| Feature | Description |
+|---------|-------------|
+| **Real-time streaming** | Browser mic → 500ms chunks → Python callback |
+| **dB calculation** | Stereo→mono, int16 normalization, RMS, dB conversion |
+| **Color-coded gauge** | ![green](https://img.shields.io/badge/-QUIET-00c853?style=flat-square) < 60dB < ![orange](https://img.shields.io/badge/-MODERATE-ff9100?style=flat-square) < 70dB < ![red](https://img.shields.io/badge/-LOUD-ff1744?style=flat-square) |
+| **Persistent alert** | Banner stays 10 seconds after loud sound. Red > yellow priority |
+| **Per-session state** | Each browser tab is independent (no cross-talk via `gr.State`) |
 
 ---
 
 ## Architecture
 
-### Request Lifecycle
-
 ```mermaid
 flowchart TB
-    subgraph Internet
-        BROWSER["Browser\nhttps://sentinel.bit-habit.com"]
-    end
-
-    subgraph Cluster["k3s Cluster (OCI Ampere A1)"]
-        TRAEFIK["Traefik Ingress\nTLS termination\n(Let's Encrypt wildcard)"]
-        SVC["Service\nsentinel-svc :80"]
-        POD["Pod\nsentinel:latest :7860"]
-    end
-
-    BROWSER -->|HTTPS :443| TRAEFIK
-    TRAEFIK -->|HTTP :80| SVC
-    SVC -->|:7860| POD
-
-    subgraph App["app.py"]
-        GRADIO["Gradio Server\nbuild_app()"]
-        AUDIO["process_audio_chunk()"]
-        LOGIC["audio_logic.py\nRMS, Pitch, Threshold"]
-        HTML["generate_status_html()\nGauge + Alert Banner"]
-    end
-
-    POD --> GRADIO
-    GRADIO -->|"WebSocket\n500ms chunks"| AUDIO
-    AUDIO --> LOGIC
-    LOGIC --> HTML
-    HTML -->|"WebSocket push"| BROWSER
+    MIC["🎤 Browser Mic"] -->|500ms chunks| PA["process_audio(chunk, state)"]
+    PA --> CVD["compute_volume_db()
+    stereo → mono
+    int16 → float
+    RMS → dB"]
+    PA --> AL["Alert Logic
+    db≥70 → 🔴 red
+    db≥60 → 🟡 yellow"]
+    PA --> GGH["generate_gauge_html()
+    color + label
+    bar width
+    banner countdown"]
+    CVD --> RET["(html, state) → browser"]
+    AL --> RET
+    GGH --> RET
 ```
 
-### Real-time Streaming
-
-```mermaid
-sequenceDiagram
-    participant B as Browser
-    participant G as Gradio
-    participant P as process_audio_chunk()
-    participant RMS as get_rms_db()
-    participant CVT as check_volume_threshold()
-    participant UI as generate_status_html()
-
-    B->>G: audio_data (sample_rate, np.ndarray)
-    G->>P: stream callback (every 500ms)
-    P->>P: resample to 16kHz if needed
-    P->>RMS: get_rms_db(audio_16k)
-    RMS-->>P: volume_db (float)
-    P->>CVT: check_volume_threshold(history, volume_db)
-    CVT-->>P: {alert_level, avg_db, peak_db}
-    P->>UI: generate_status_html(app_state)
-    UI-->>B: Updated HTML via WebSocket
-```
+Each callback is **stateless** except for `SessionState` (managed via `gr.State`), which stores alert expiration timestamps. No global variables — each browser tab gets independent state, like C's thread-local storage.
 
 ---
 
-## Roadmap
+## How This Was Built
 
-Each version adds a new layer of intelligence.
+### Pair Programming with Claude Code — but I hold the keyboard
 
-| Version | Milestone | Status |
-|---------|-----------|--------|
-| **v0.0** | Volume gauge + 10s persistent alert | **Deployed** |
-| **v0.1** | Pitch detection + adaptive sensitivity + mobile vibration | **Deployed** |
-| v0.2 | VAD-gated emotion detection (Silero + OpenAI Realtime API) | Planned |
-| v0.3 | Speaker diarization + color-coded transcript | Planned |
-| v0.4 | Claim detection + fact-checking (Tavily) | Planned |
-| v0.5 | Edge AI migration (local vLLM, $0 token cost) | Planned |
-| v1.0 | Slack/Zoom alerts + autonomous verbal mediation | Planned |
+This project follows a strict **pair programming** model:
+
+```mermaid
+flowchart LR
+    subgraph Claude["🔊 Claude Code — can only TALK"]
+        C1["Explains concepts
+        (C analogies)"]
+        C2["Reviews code
+        (bug / security / perf)"]
+    end
+    subgraph Gichan["⌨️ Gichan — only one with KEYBOARD"]
+        G1["Types every line
+        of code"]
+        G2["Types every
+        git command"]
+        G3["Decides what
+        to commit"]
+    end
+    Claude <-->|"conversation"| Gichan
+```
+
+**What this means concretely:**
+- **Every `git commit`, `git push`, `python app.py`** — typed by me in my terminal
+- **Every line of `app.py`** — typed by me in VS Code
+- **Claude's role** — explain concepts (using C analogies since I have 2+ years of C), provide scaffolds to study, review code for bugs, answer "why?" questions
+- **My rule** — never commit code I can't explain line by line
+
+### Why this matters
+
+Most AI-assisted portfolios are ambiguous: "Did the AI write it, or did the human?" This project has a clear answer:
+
+| Role | Who |
+|------|-----|
+| Architecture decisions | Me (with Claude's input) |
+| Typing code | **Me — always** |
+| Typing git commands | **Me — always** |
+| Understanding each line | **Me — before every commit** |
+| Code review | Claude (via custom review skill) |
+| Bug explanations | Claude (I ask "why?", it explains) |
+| Framework comparison (Gradio vs Streamlit) | Both (I asked, Claude analyzed, I decided) |
+
+**Evidence:** Every PR has a "Learning Notes" section written by me, documenting what I understood, what surprised me, and what mistakes I made. These are not generated — they reflect my actual learning moments.
+
+---
+
+## Learning Journey
+
+### The Build-Up — each row is one merged PR
+
+| PR | What was built | What I learned |
+|----|---------------|----------------|
+| [#10](../../pull/10) | ![chore](https://img.shields.io/badge/-chore-grey?style=flat-square) Project scaffolding | `.gitignore` doesn't ignore already-tracked files — need `git rm --cached`. `pip freeze` captures transitive deps |
+| [#14](../../pull/14) | ![feat](https://img.shields.io/badge/-feat-00c853?style=flat-square) Mic streaming + metadata | Callback = C function pointer. `inputs`/`outputs` decouple event source from data source. Browser sends stereo int16 at 48kHz |
+| [#17](../../pull/17) | ![feat](https://img.shields.io/badge/-feat-00c853?style=flat-square) Real-time dB calculation | `numpy.mean()` silently converts int16→float64, breaking dtype checks. Fix: save `original_dtype` before operations |
+| [#18](../../pull/18) | ![fix](https://img.shields.io/badge/-fix-ff1744?style=flat-square) dtype normalization bug | Caught by code review: `np.iinfo(audio.dtype)` fails after `.mean()` changes dtype. One-line fix |
+| [#19](../../pull/19) | ![feat](https://img.shields.io/badge/-feat-00c853?style=flat-square) HTML gauge + thresholds | f-string HTML generation. `min(max(x,0),100)` = clamp. CSS `transition` for animation. Pure function = testable |
+| #20 | ![feat](https://img.shields.io/badge/-feat-00c853?style=flat-square) Persistent alert banner | `gr.State` = per-session state (C thread-local). `time.time()` > countdown int. Tuple return for multiple outputs |
+
+### Key Decisions
+
+| Decision | Chosen | Alternative | Why |
+|----------|--------|-------------|-----|
+| **Framework** | ![Gradio](https://img.shields.io/badge/-Gradio-f97316?style=flat-square) | Streamlit | Native `streaming=True` for real-time mic. Streamlit needs third-party WebRTC |
+| **dB math** | ![NumPy](https://img.shields.io/badge/-Local_NumPy-013243?style=flat-square) | Cloud API | $0 cost, <10ms, no network. Volume = signal math, not AI |
+| **State** | ![gr.State](https://img.shields.io/badge/-gr.State-blue?style=flat-square) | Global variable | Per-session isolation. Global var = cross-talk between tabs |
+| **CSS** | Inline | Separate file | Single-file simplicity for small components |
+| **Dev pattern** | Stub first | Write full logic | `return 0.0` → test wiring → fill logic. Bugs stay localized |
+
+### Development Workflow
+
+```
+1. Goal       — I state what to build (one sentence)
+2. Scaffold   — Claude shows a starting point (I read, don't copy blindly)
+3. Understand — I ask "why?" on anything unclear
+4. Type       — I write the code myself, line by line
+5. Test       — python app.py after every change
+6. Commit     — only code I can explain
+7. Review     — Claude runs 4-axis review (bug / security / perf / convention)
+8. Merge      — squash merge, close issue with learning summary
+```
+
+> **The keyboard never leaves my hands.** Claude is the senior who reviews over my shoulder and explains when I'm stuck — but never grabs the mouse.
 
 ---
 
 ## Tech Stack
 
-| Layer | Technology | Why |
-|-------|-----------|-----|
-| Frontend | Gradio 4.0+ | Python-native streaming, fast prototyping |
-| Audio Math | NumPy | RMS/dB/FFT, zero dependencies, < 10ms |
-| Container | Docker + Python 3.10 slim | Lightweight, reproducible |
-| Orchestration | K3s on Oracle OCI | Free tier, production Kubernetes |
-| Ingress | Traefik + cert-manager | Auto TLS via Let's Encrypt wildcard |
-| GitOps | ArgoCD | Declarative deployment, auto-sync |
+| Component | Technology | Why |
+|-----------|-----------|-----|
+| ![Python](https://img.shields.io/badge/-Python_3.14-3776ab?style=flat-square&logo=python&logoColor=white) | Language | Cutting-edge stable, full ecosystem |
+| ![Gradio](https://img.shields.io/badge/-Gradio_6.12-f97316?style=flat-square) | UI Framework | Native audio streaming, no JS needed |
+| ![NumPy](https://img.shields.io/badge/-NumPy_2.4-013243?style=flat-square&logo=numpy) | Audio Math | RMS/dB in <10ms, zero cost |
+| ![GitHub](https://img.shields.io/badge/-GitHub-181717?style=flat-square&logo=github) | Version Control | Issue→PR→Review→Merge workflow |
+| ![Claude](https://img.shields.io/badge/-Claude_Code-cc785c?style=flat-square&logo=anthropic&logoColor=white) | Pair Programming | Senior co-pilot (talk only, no keyboard) |
+| ![Playwright](https://img.shields.io/badge/-Playwright_MCP-2ead33?style=flat-square) | Browser Testing | CDP mode, visual verification |
+
+---
+
+## Quick Start
+
+```bash
+git clone https://github.com/bookseal/sentinel-real-time-cognitive-assistant.git
+cd sentinel-real-time-cognitive-assistant
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+python app.py
+# Open http://localhost:7860 — grant microphone permission
+```
 
 ---
 
@@ -180,68 +168,34 @@ Each version adds a new layer of intelligence.
 
 ```
 sentinel-real-time-cognitive-assistant/
-├── app.py               # Gradio app — streaming + gauge + alert
-├── audio_logic.py       # RMS, dB, pitch (FFT), threshold logic
-├── vad.py               # Voice Activity Detection (future)
-├── audio_buffer.py      # Circular buffer for speech chunks (future)
-├── requirements.txt     # gradio, numpy
-├── Dockerfile
-├── CLAUDE.md            # Claude Code project instructions
-├── k8s/
-│   ├── deployment.yaml
-│   ├── service.yaml
-│   ├── ingress.yaml
-│   └── secret.yaml.example
-└── docs/
-    ├── guide-v0.0-volume-gauge.md
-    ├── guide-v0.1-pitch-guard.md
-    └── guide-request-lifecycle.md
+├── app.py               # Main app — 3 functions, ~95 lines
+│                        #   generate_gauge_html()  — HTML rendering
+│                        #   compute_volume_db()    — audio → dB
+│                        #   process_audio()        — orchestrator
+├── requirements.txt     # gradio + numpy (49 packages via pip freeze)
+├── CLAUDE.md            # Project conventions + balanced workflow rules
+├── .claude/skills/
+│   ├── review/          # 4-axis code review (bug/security/perf/convention)
+│   └── fix-issue/       # Issue-driven debugging workflow
+└── .gitignore
 ```
 
----
-
-## Quick Start
-
-```bash
-# Run locally
-git clone git@github.com:bookseal/sentinel-real-time-cognitive-assistant.git
-cd sentinel-real-time-cognitive-assistant
-pip install -r requirements.txt
-python app.py
-# Open http://localhost:7860
-
-# Or via Docker
-docker build -t sentinel:latest .
-docker run -p 7860:7860 sentinel:latest
-
-# Deploy to K3s
-docker save sentinel:latest | sudo k3s ctr images import -
-kubectl rollout restart deployment/sentinel
-```
+Code follows [norminette-inspired conventions](CLAUDE.md): max 7 functions/file, max 30 lines/function, single responsibility, flat over nested.
 
 ---
 
-## Git Workflow
+## Roadmap
 
-| Branch | Purpose |
-|--------|---------|
-| `main` | Production (deployed to K3s) |
-| `feature/*` | New features |
-| `fix/*` | Bug fixes |
-| `docs/*` | Documentation only |
-
-Tags: [Semantic Versioning](https://semver.org/) · Commits: [Conventional Commits](https://www.conventionalcommits.org/)
+| Version | Milestone | Status |
+|---------|-----------|--------|
+| ![v0.1](https://img.shields.io/badge/-v0.1-00c853?style=flat-square) | Volume gauge + persistent alert | **Current** |
+| ![v0.2](https://img.shields.io/badge/-v0.2-ff9100?style=flat-square) | VAD-gated emotion detection (Silero + OpenAI) | Planned |
+| ![v0.3](https://img.shields.io/badge/-v0.3-2196f3?style=flat-square) | Full pipeline + deployment | Planned |
 
 ---
 
-## Docs
+## Background
 
-| Document | What's inside |
-|----------|---------------|
-| [v0.0 Guide](docs/guide-v0.0-volume-gauge.md) | Build, deploy, traffic flow, k8s concepts |
-| [v0.1 Flow](docs/guide-v0.1-pitch-guard.md) | RMS math, sliding window, edge cases |
-| [Request Lifecycle](docs/guide-request-lifecycle.md) | Full trace: browser → TLS → k8s → HTML |
+Built on [42 Seoul](https://42seoul.kr) foundations — 2+ years of C, from `malloc` to `pthread`. This project is a deliberate transition from systems programming to full-stack Python, documenting the journey from `printf("hello")` to real-time audio streaming in the browser.
 
----
-
-Built on 42 Seoul foundations. Deployed via K3s on Oracle OCI.
+The entire git history — from empty repo to working app — is preserved as a learning artifact. Each issue, PR, and commit message tells the story of one developer learning by building, with a senior AI pair-programmer who was only allowed to talk.

--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ import gradio as gr
 import numpy as np
 import time
 
-def generate_gauge_html(db):
+def generate_gauge_html(db, state=None):
     """Return HTML with volume bar + color label."""
     if db >= 70:
         color, label = "red", "LOUD"
@@ -61,6 +61,15 @@ def process_audio(audio_data, state):
         return generate_gauge_html(0), state
     sample_rate, audio = audio_data
     db = compute_volume_db(audio)
+
+    if db >= ALERT_DB:
+        state.alert_until = time.time() + ALERT_DURATION
+        state.alert_level = "red"
+    elif db >= WARNING_DB:
+        if state.alert_until - time.time() <= 0 or state.alert_level != "red":
+            state.alert_until = time.time() + ALERT_DURATION
+            state.alert_level = "yellow"
+
     return generate_gauge_html(db), state
 
 with gr.Blocks(title = "Sentinel") as app:

--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 import gradio as gr
 import numpy as np
+import time
 
 def generate_gauge_html(db):
     """Return HTML with volume bar + color label."""
@@ -24,6 +25,14 @@ def generate_gauge_html(db):
     </div>
     """
 
+WARNING_DB = 60.0
+ALERT_DB = 70.0
+ALERT_DURATION = 10
+
+class SessionState:
+    def __init__(self):
+        self.alert_until = 0.0
+        self.alert_level = ""
 
 def compute_volume_db(audio):
     """Convert raw audio samples to decibels (dB)."""
@@ -45,21 +54,24 @@ def compute_volume_db(audio):
     db = 20 * np.log10(rms) + 94
     return max(db, 0.0)
 
-def process_audio(audio_data):
+def process_audio(audio_data, state):
+    if state is None:
+        state = SessionState()
     if audio_data is None:
-        return generate_gauge_html(0)
+        return generate_gauge_html(0), state
     sample_rate, audio = audio_data
     db = compute_volume_db(audio)
-    return generate_gauge_html(db)
+    return generate_gauge_html(db), state
 
-with gr.Blocks() as app:
+with gr.Blocks(title = "Sentinel") as app:
     gr.Markdown("# Sentinel - Volume Monitor")
     audio_input = gr.Audio(sources="microphone", streaming=True, type="numpy")
     output = gr.HTML(value=generate_gauge_html(0))
+    session_state = gr.State(value=None)
     audio_input.stream(
         fn=process_audio,
-        inputs=[audio_input],
-        outputs=[output],
+        inputs=[audio_input, session_state],
+        outputs=[output, session_state],
     )
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -1,29 +1,6 @@
+import time
 import gradio as gr
 import numpy as np
-import time
-
-def generate_gauge_html(db, state=None):
-    """Return HTML with volume bar + color label."""
-    if db >= 70:
-        color, label = "red", "LOUD"
-    elif db >= 60:
-        color, label = "orange", "MODERATE"
-    else:
-        color, label = "green", "QUIET"
-
-    pct = min(max((db - 30) / 70 * 100, 0), 100)
-
-    return f"""
-    <div style="padding:16px;">
-        <p><strong>Volume:</strong> {db:.1f} dB -
-            <span style="color:{color};">{label}</span></p>
-        <div style="background:#ddd; border-radius:8px; height:24px;">
-            <div style="width:{pct:.1f}%; height:100%; background:{color};
-                border-radius:8px; transition:width 0.15s;">
-            </div>
-        </div>
-    </div>
-    """
 
 WARNING_DB = 60.0
 ALERT_DB = 70.0
@@ -33,6 +10,43 @@ class SessionState:
     def __init__(self):
         self.alert_until = 0.0
         self.alert_level = ""
+
+def generate_gauge_html(db, state=None):
+    """Return HTML with volume bar + color label."""
+    if db >= ALERT_DB:
+        color, label = "red", "LOUD"
+    elif db >= WARNING_DB:
+        color, label = "orange", "MODERATE"
+    else:
+        color, label = "green", "QUIET"
+
+    pct = min(max((db - 30) / 70 * 100, 0), 100)
+
+    banner = ""
+    if state and state.alert_until - time.time() > 0:
+        remaining = state.alert_until - time.time()
+        a_color = "red" if state.alert_level == "red" else "orange"
+        a_text = ("ALERT - Voice Too Loud" if a_color == "red"
+                else "CAUTION - Volume Rising")
+        banner = f"""
+        <div style="padding:12px; margin-bottom:12px; border-radius:8px;
+            background:{a_color}; color:white; text-align:center;">
+            <strong>{a_text}</strong>
+            <span style="opacity:0.8; margin-left:8px;">({remaining:.0f}s)</span>
+        </div>"""
+    
+    return f"""
+    <div style="padding:16px;">
+        {banner}
+        <p><strong>Volume:</strong> {db:.1f} dB
+        <span style="color:{color};">{label}</span></p>
+        <div style="background:#ddd; border-radius:8px; height:24px;">
+            <div style="width:{pct:.1f}%; height:100%; background:{color};
+            border-radius:8px; transition:width 0.15s;">
+            </div>
+        </div>
+    </div>
+    """
 
 def compute_volume_db(audio):
     """Convert raw audio samples to decibels (dB)."""
@@ -70,9 +84,9 @@ def process_audio(audio_data, state):
             state.alert_until = time.time() + ALERT_DURATION
             state.alert_level = "yellow"
 
-    return generate_gauge_html(db), state
+    return generate_gauge_html(db, state), state
 
-with gr.Blocks(title = "Sentinel") as app:
+with gr.Blocks(title="Sentinel") as app:
     gr.Markdown("# Sentinel - Volume Monitor")
     audio_input = gr.Audio(sources="microphone", streaming=True, type="numpy")
     output = gr.HTML(value=generate_gauge_html(0))


### PR DESCRIPTION
## Summary

- Persistent alert banner: red (70+ dB) / yellow (60+ dB), stays 10 seconds after sound drops
- Per-session state via `gr.State` — no cross-talk between browser tabs
- Red alert takes priority over yellow
- README completely rewritten as learning portfolio with mermaid architecture diagrams

## Test plan

- [x] Loud voice (70+) → red banner with countdown
- [x] Moderate voice (60+) → yellow banner
- [x] Banner persists 10s after going quiet
- [x] Red alert not overwritten by yellow
- [x] Unit tests pass (compute_volume_db + generate_gauge_html)

## Learning notes

- **gr.State** = per-session state container, same concept as C thread-local storage. Each browser tab gets independent state
- **Timestamp vs countdown** — storing alert_until = time.time() + 10 is simpler than decrementing a counter
- **Multiple return values** — Python tuple return (html, state) maps 1:1 to outputs=[output, session_state]
- **Magic number trap** — initially hardcoded 60/70 while constants existed elsewhere. Would silently diverge
- **Import order** — PEP 8: stdlib first, then third-party

Closes #20
