### PR TITLE
refactor: extract audio_logic.py from app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,25 +48,6 @@ def generate_gauge_html(db, state=None):
     </div>
     """
 
-def compute_volume_db(audio):
-    """Convert raw audio samples to decibels (dB)."""
-    if len(audio) == 0:
-        return 0.0
-    
-    original_dtype = audio.dtype
-
-    if audio.ndim > 1:
-        audio = audio.mean(axis=1)
-    
-    audio_f = audio.astype(np.float32)
-    if np.issubdtype(original_dtype, np.integer):
-        audio_f = audio_f / max(np.iinfo(original_dtype).max, 1)
-
-    rms = float(np.sqrt(np.mean(audio_f ** 2)))
-    if rms < 1e-10:
-        return 0.0
-    db = 20 * np.log10(rms) + 94
-    return max(db, 0.0)
 
 def process_audio(audio_data, state):
     if state is None:

--- a/audio_logic.py
+++ b/audio_logic.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+def compute_volume_db(audio):
+    """Convert raw audio samples to decibels (dB)."""
+    if len(audio) == 0:
+        return 0.0
+    
+    original_dtype = audio.dtype
+
+    if audio.ndim > 1:
+        audio = audio.mean(axis=1)
+    
+    audio_f = audio.astype(np.float32)
+    if np.issubdtype(original_dtype, np.integer):
+        audio_f = audio_f / max(np.iinfo(original_dtype).max, 1)
+
+    rms = float(np.sqrt(np.mean(audio_f ** 2)))
+    if rms < 1e-10:
+        return 0.0
+    db = 20 * np.log10(rms) + 94
+    return max(db, 0.0)
+
+


### PR DESCRIPTION
## Summary

- Extract `compute_volume_db` and `resample_to_16k` into `audio_logic.py`
- `app.py` now imports from `audio_logic` instead of defining signal math inline
- Follows single-responsibility principle: signal math vs app orchestration

## Why

`app.py` was approaching norminette limits (150 lines, 7 functions). With VAD and sensitivity slider coming next, module separation needed now before it gets worse.

## Test plan

- [x] `python app.py` works identically to before (gauge + alert)
- [x] No behavior change — pure refactor

## Learning notes

- **"What changes together goes together"** — senior principle for module separation
- `audio_logic.py` changes when audio format/math changes; `app.py` changes when UI/orchestration changes
- Import direction is one-way: app.py -> audio_logic.py, never reverse
